### PR TITLE
[DNM] Have schedule be in user timezone

### DIFF
--- a/.deploy-ghpages.sh
+++ b/.deploy-ghpages.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    echo "Generating an pushing docs to github pages"
+#!/bin/sh
+
+if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    echo "Generating and pushing docs to github pages"
     cd docs/html/
     git init
     git config user.name "Travis CI"

--- a/config/Config.js
+++ b/config/Config.js
@@ -20,10 +20,10 @@ module.exports = {
   onaFormIdString: env.ONA_FORM_ID_STRING,
   onaApiToken: env.ONA_API_TOKEN,
   rapidproApiToken: env.RAPIDPRO_API_TOKEN,
-  rapidproGroups: env.RAPIDPRO_GROUPS ? JSON.parse(env.RAPIDPRO_GROUPS) : [],
+  rapidproGroups: env.RAPIDPRO_GROUPS ? JSON.parse(env.RAPIDPRO_GROUPS) : {},
   deletedUserGroups: env.DELETED_USER_RAPIDPRO_GROUPS ?
     JSON.parse(env.DELETED_USER_RAPIDPRO_GROUPS) :
-    [],
+    {},
 
   // logging and error reporting
   sentryDSN: env.SENTRY_DSN,

--- a/docs/Env.md
+++ b/docs/Env.md
@@ -3,24 +3,33 @@
 None of these vars is required by themselves but you need to set a few of
  them to create a functioning bot.
 
-|        Environment variable      |                                                                            Descpription                                                               |         Default         |
-|:--------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------:|
-|NODE_ENV                          |test, dev and production                                                                                                                               |'dev'                    |
-|DEAFULT_LANGUAGE (ISO 639-1 Code) |The language you want the bot to communicate in.                                                                                                       |'en'                     |
-|HOST_PORT (docker)                |Container port in the host                                                                                                                             |undefined                |
-|APP_PORT (docker)                 |App port in the container                                                                                                                              |3000                     |
-|PORT                              |POrt that your bot is listening on. If in docker APP_PORT = PORT                                                                                       |3000                     |
-|ONA_USERNAME                      |Ona user or organization username                                                                                                                      |undefined                |
-|ONA_FORM_ID_STRING                |Ona provides an id_string for every form. We use it to identify the form to send data to.                                                              |undefined                |
-|ONA_API_TOKEN                     |API token provided by Ona. Required if sending data to Ona.                                                                                            |undefined                |
-|RAPIDPRO_API_TOKEN                |API token provided by Rapidpro. Required if creating or updating RapidPro contacts.                                                                    |undefined                |
-|RAPIDPRO_GROUPS                   |List of Rapidpro group UUIDs that your users should be added to e.g `export RAPIDPRO_GROUPS="[\"68g77390-4hcd-4cf8-b985-da286e0790y3\"]"`              |[]                       |
-|DELETED_USER_RAPIDPRO_GROUPS      |List of Rapidpro group UUIDs that your users should be moved to e.g `export DELETED_USER_RAPIDPRO_GROUPS="[\"68g77390-4hcd-4cf8-b985-da286e0790y3\"]"` |[]                       |
-|SENTRY_DSN                        |DSN provided by Sentry                                                                                                                                 |undefined                |
-|ACCESS_LOG_FILE                   |File to store access logs                                                                                                                              |bot.access.log           |
-|DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                                                                                       |false                    |
-|FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve                                                                    |'borq'                   |
-|FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                                                                                  |undefined                |
-|CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                                                                                  |60000 * 20 (20 mins)     |
-|FACEBOOK_PAGE_ACCESS_TOKEN        |Facebook provided token needed to post as a page. Required for Messenger.                                                                              |undefined                |
-|FACEBOOK_API_VERSION              |The version of the facebook API to use when making Facebook API calls.                                                                                 |'v2.10'                  |
+|        Environment variable      |                                     Descpription                                           |         Default         |
+|:--------------------------------:|:------------------------------------------------------------------------------------------:|:-----------------------:|
+|NODE_ENV                          |test, dev and production                                                                    |'dev'                    |
+|DEAFULT_LANGUAGE (ISO 639-1 Code) |The language you want the bot to communicate in.                                            |'en'                     |
+|HOST_PORT (docker)                |Container port in the host                                                                  |undefined                |
+|APP_PORT (docker)                 |App port in the container                                                                   |3000                     |
+|PORT                              |POrt that your bot is listening on. If in docker APP_PORT = PORT                            |3000                     |
+|ONA_USERNAME                      |Ona user or organization username                                                           |undefined                |
+|ONA_FORM_ID_STRING                |Ona provides an id_string for every form. We use it to identify the form to send data to.   |undefined                |
+|ONA_API_TOKEN                     |API token provided by Ona. Required if sending data to Ona.                                 |undefined                |
+|RAPIDPRO_API_TOKEN                |API token provided by Rapidpro. Required if creating or updating RapidPro contacts.         |undefined                |
+|RAPIDPRO_GROUPS                   |JSON Object of keys to Rapidpro group UUIDs that your users should be added to              |[]                       |
+|DELETED_USER_RAPIDPRO_GROUPS      |JSON Object of keys to Rapidpro group UUIDs that your users should be moved to e.g          |[]                       |
+|SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                |
+|ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log           |
+|DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                    |
+|FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                   |
+|FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                |
+|CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)     |
+|FACEBOOK_PAGE_ACCESS_TOKEN        |Facebook provided token needed to post as a page. Required for Messenger.                   |undefined                |
+|FACEBOOK_API_VERSION              |The version of the facebook API to use when making Facebook API calls.                      |'v2.10'                  |
+
+
+
+
+examples:
+```
+$ export DELETED_USER_RAPIDPRO_GROUPS='{"del": "68g77390-4hcd-4cf8-b985-da286e0790y36"}'
+$ export RAPIDPRO_GROUPS='{"in": "68g77390-4hcd-4cf8-b985-da286e0790y36", "br": "68g77390-4hcd-4cf8-b985-da286e0790y36"}'
+```

--- a/lib/Services.js
+++ b/lib/Services.js
@@ -6,7 +6,6 @@ const Config = require('../config/Config.js');
 const aggregate = require('../lib/Aggregate.js');
 const http = require('../lib/HTTP.js');
 const utils = require('./utils/Utils.js');
-const localeUtils = require('./utils/Locales.js');
 
 const rapidproURL = 'https://rapidpro.ona.io/api/v2/contacts.json';
 const onaSubmissionEndpointURL = `https://api.ona.io/${Config.onaOrg}/submission`;
@@ -65,12 +64,18 @@ function getFacebookProfile(fbMessengerId) {
 /**
 * Create a user
 * Default language Config.defaultLanguage
-* @param {string} messengerId The messeger ID of the current user
-* @param {string} referrer The rapidpro contact uuid of the user who sent them
-* a link to the bot
-* @return {promise} A promise with the newly created rapidpro contact
+* @param {String} messengerId The messeger ID of the current user
+* @param {Array} rapidproGroups Array of rapidpro groups to add a user to
+* @param {String} language An ISO6392 language code string
+* @param {Object} profile The user profile object from facebook
+* @param {Object} extraFields other fields to add to the rapidpro contact
+* @return {Promise} A promise with the newly created rapidpro contact
 */
-function createUser(messengerId, rapidproGroups, language, profile, extraFields) {
+function createUser(messengerId,
+                    rapidproGroups,
+                    language,
+                    profile,
+                    extraFields) {
   return genAndPostRapidproContact(rapidproGroups,
                                    language,
                                    messengerId,
@@ -146,7 +151,7 @@ function genRapidproContact(groups,
                                  timezone,
                                  gender,
                                  is_payment_enabled,
-                               })
+                               }),
   };
 }
 

--- a/lib/Services.js
+++ b/lib/Services.js
@@ -70,20 +70,12 @@ function getFacebookProfile(fbMessengerId) {
 * a link to the bot
 * @return {promise} A promise with the newly created rapidpro contact
 */
-function createUser(messengerId, referrer) {
-  return getFacebookProfile(messengerId)
-    .then((profile) => {
-      const language =
-            localeUtils.lookupISO6392(profile.locale || Config.defaultLanguage);
-      return genAndPostRapidproContact(Config.rapidproGroups,
-                                       language,
-                                       messengerId,
-                                       profile,
-                                       {referrer});
-    })
-    .catch((reason) =>
-           http.genericCatchRejectedPromise('Failed to fetch Facebook profile' +
-                                            `in createUser: ${reason}`));
+function createUser(messengerId, rapidproGroups, language, profile, extraFields) {
+  return genAndPostRapidproContact(rapidproGroups,
+                                   language,
+                                   messengerId,
+                                   profile,
+                                   extraFields);
 }
 
 /**
@@ -154,7 +146,7 @@ function genRapidproContact(groups,
                                  timezone,
                                  gender,
                                  is_payment_enabled,
-                               }),
+                               })
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "borq",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Bot orchestration framework",
   "main": "lib/Borq.js",
   "scripts": {


### PR DESCRIPTION
Have RAPIDPRO_GROUPS and DELETED_USER_RAPIDPRO_GROUPS be an object. This makes it easier to know which group holds what.

Passing `rapidProGroups` as an arg to `createUser` means we can have a function that defines which group to add a user to based on logic sitting elsewhere, preferably in the bot.

Fixes #23 
