### PR TITLE
Update to botkit 0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Todo:
  - Telegram
 
 ## Run an example bot
+
+`$ FACEBOOK_PAGE_ACCESS_TOKEN= FACEBOOK_APP_SECRET= FACEBOOK_VERIFY_TOKEN= yarn dev`
+
 ```javascript
 const borq = require('borq');
 const {
@@ -25,43 +28,58 @@ const {
   config
 } = borq;
 
+const {controller} = facebook;
+const botty = controller.spawn({});
+
 /*
 * Set Messenger Profile API
 * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
 */
-facebook.setGetStarted('start');
-facebook.setGreeting('Hello, I am a bot.');
 facebook.setMenu([
   {
     locale: 'default',
     composer_input_disabled: true,
     call_to_actions: [
-      {
-        type: 'web_url',
-        title: 'FAQ',
-        url: 'https://goodbotai.github.io/borq/',
-        webview_height_ratio: 'full',
-      }
-    ]
-  }
+         {
+           title: 'Restart',
+           type: 'postback',
+           payload: 'restart',
+         }, {
+           title: 'Other',
+           type: 'postback',
+           payload: 'other',
+         }, {
+           type: 'web_url',
+           title: 'FAQ',
+           url: 'https://goodbotai.github.io/borq/',
+           webview_height_ratio: 'full',
+         }
+       ],
+  },
 ]);
+facebook.setGetStarted('start');
+facebook.setGreeting('Hello, I am a bot.');
 
-facebook.borqBot.on('facebook_postback', (bot, message) => {
+controller.on('facebook_postback', (bot, message) => {
   if (message.payload === 'start') {
     bot.startConversation(message, (err, convo) => {
-      convo.addMessage('Started');
+      convo.addMessage('Welcome to my lair!');
     });
   } else {
     bot.startConversation(message, (err, convo) => {
-      convo.addMessage(t('hello'));
+      convo.addMessage('Hello, you added a postback?');
     });
   }});
 
-facebook.borqBot.hears(['hello'],
-                          'message_received',
-                          (bot, message) => bot.reply(message, t('key')));
-
-const botty = facebook.borqBot.spawn({});
+controller.hears(['talk'],
+                 'message_received',
+                 (bot, message) => {
+                   bot.startConversation(message, (err, convo) => {
+                     convo.addQuestion('Say something',
+                                       (res, con) => con.next());
+                     convo.addQuestion('Ok bye', (res, con) => con.next());
+                   });
+                 });
 
 facebook.start(botty, (err, webserver) => {
   // Add routes for your bot to listen on

--- a/config/Config.js
+++ b/config/Config.js
@@ -11,7 +11,7 @@ module.exports = {
   environment: env.NODE_ENV || 'development', // dev, prod, test
   PORT: env.PORT || env.APP_PORT || 3000, // env to run karma on
   defaultLanguage: env.DEFAULT_LANGUAGE || 'en',
-  translationsDir: env.TRANSLATIONS_DIR,
+  translationsDir: env.TRANSLATIONS_DIR || './translations',
 
   // milliseconds per min * number of mins
   conversationTimeout: env.CONVERSATION_TIMEOUT || (60000 * 20),

--- a/config/Config.js
+++ b/config/Config.js
@@ -11,7 +11,7 @@ module.exports = {
   environment: env.NODE_ENV || 'development', // dev, prod, test
   PORT: env.PORT || env.APP_PORT || 3000, // env to run karma on
   defaultLanguage: env.DEFAULT_LANGUAGE || 'en',
-  translationsDir: env.TRANSLATIONS_DIR || './translations',
+  translationsDir: env.TRANSLATIONS_DIR,
 
   // milliseconds per min * number of mins
   conversationTimeout: env.CONVERSATION_TIMEOUT || (60000 * 20),

--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -17,7 +17,7 @@ them to create a functioning bot.
 |SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                |
 |ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log           |
 |DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                    |
-|TRANSLATIONS_DIR                  |Path to the dir holding the translations files                                              |'./translations'         |
+|TRANSLATIONS_DIR                  |Path to the dir holding the translations files                                              |undefined                |
 |FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                   |
 |FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                |
 |CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)     |

--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -17,7 +17,7 @@ them to create a functioning bot.
 |SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                |
 |ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log           |
 |DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                    |
-|TRANSLATIONS_DIR                  |Path to the dir holding the translations files                                              |undefined                |
+|TRANSLATIONS_DIR                  |Path to the dir holding the translations files.                                             |'./translations'         |
 |FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                   |
 |FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                |
 |CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)     |

--- a/index.js
+++ b/index.js
@@ -1,71 +1,61 @@
-const borq = require('borq');
-const facebookBot = borq.facebookBot;
+const {facebook} = require('./lib/Borq.js');
+const {controller} = facebook;
+const botty = controller.spawn({});
 
 /*
 * Set Messenger Profile API
 * https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
 */
-facebookBot.setGetStarted('start');
-facebookBot.setGreeting('Hello, I am a bot.');
-facebookBot.setMenu([
+facebook.setMenu([
   {
-    locale: 'in_ID',
-    composer_input_disabled: true,
-    call_to_actions: [
-      {
-        type: 'web_url',
-        title: 'FAQ',
-        url: 'https://goodbotai.github.io/borq/',
-        webview_height_ratio: 'full',
-      },
-    ],
-  }, {
     locale: 'default',
     composer_input_disabled: true,
     call_to_actions: [
-      {title: '',
-       type: 'nested',
-       call_to_actions: [
          {
-           title: 'English',
+           title: 'Restart',
            type: 'postback',
-           payload: 'english',
+           payload: 'restart',
+         }, {
+           title: 'Other',
+           type: 'postback',
+           payload: 'other',
+         }, {
+           type: 'web_url',
+           title: 'FAQ',
+           url: 'https://goodbotai.github.io/borq/',
+           webview_height_ratio: 'full',
          },
-        {
-          title: 'Bahasa',
-          type: 'postback',
-          payload: 'bahasa',
-        },
        ],
-      },
-    ],
   },
 ]);
+facebook.setGetStarted('start');
+facebook.setGreeting('Hello, I am a bot.');
 
-facebookBot.on('facebook_postback', (bot, message) => {
+controller.on('facebook_postback', (bot, message) => {
   if (message.payload === 'start') {
     bot.startConversation(message, (err, convo) => {
-      convo.addMessage('Started');
+      convo.addMessage('Welcome to my lair!');
     });
-  } else if (message.payload === 'english') {
+  } else {
     bot.startConversation(message, (err, convo) => {
-      convo.addMessage('Hello');
-    });
-  } else if (message.payload === 'bahasa') {
-    bot.startConversation(message, (err, convo) => {
-      convo.addMessage('Halo');
+      convo.addMessage('Hello, you added a postback?');
     });
   }
 });
 
-facebookBot.hears(['hello'],
-                  'message_received',
-                  (bot, message) => {
-                    bot.reply(message, 'How\'s your day going?');
-});
+controller.hears(['talk'],
+                 'message_received',
+                 (bot, message) => {
+                   bot.startConversation(message, (err, convo) => {
+                     convo.addQuestion('Say something',
+                                       (res, con) => con.next());
+                     convo.addQuestion('Ok bye', (res, con) => con.next());
+                   });
+                 });
 
-facebookBot.hears([/([a-z])\w+/gi],
-                  'message_received',
-                  function(bot, message) {
-                    bot.reply(message, 'I don\'t know that word yet');
+facebook.start(botty, (err, webserver) => {
+  // Add routes for your bot to listen on
+  webserver.get('/', (req, res) => {
+    res.send('<h3>This is a bot</h3>');
+  });
 });

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -68,15 +68,6 @@ function start(bot, cb) {
       webserver.use(Services.sentry.requestHandler());
     }
 
-    webserver.use(expressWinston.logger({
-      transports: [
-        new winston.transports.File({
-          filename: Config.karmaAccessLogFile,
-          logstash: true,
-          zippedArchive: true,
-        })],
-    }));
-
     cb(err, webserver);
 
     controller.createWebhookEndpoints(webserver, bot, () => {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -7,11 +7,6 @@ const Config = require('../config/Config.js');
 const Services = require('./Services.js');
 
 const controller = Botkit.facebookbot({
-  logger: new winston.Logger({
-    transports: [
-      new (winston.transports.Console)({level: 'debug'}),
-    ],
-  }),
   debug: true,
   log: true,
   access_token: Config.facebookPageAccessToken,
@@ -20,7 +15,6 @@ const controller = Botkit.facebookbot({
   receive_via_postback: true,
   validate_requests: true,
   stats_optout: true,
-  require_delivery: true,
 });
 
 // Create a messenger profile API so that your bot seems more human.
@@ -93,6 +87,7 @@ function start(bot, cb) {
       webserver.use(Services.sentry.errorHandler());
     }
   });
+  controller.startTicking();
 }
 
 module.exports = {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -1,7 +1,6 @@
 /** @module facebook */
 const winston = require('winston');
 const Botkit = require('botkit');
-const expressWinston = require('express-winston');
 
 const Config = require('../config/Config.js');
 const Services = require('./Services.js');

--- a/lib/Translations.js
+++ b/lib/Translations.js
@@ -9,6 +9,7 @@ const config = require('../config/Config.js');
 /**
 * Generate namespaces needed by i18next from the files in the translations
 * directory e.g ['en', 'in']
+* @param {string} dir - Directory containing translation files
 * @return {array} an array of strings that should be iso6391 language codes
 */
 function generateNameSpaces(dir) {
@@ -48,7 +49,6 @@ if (config.translationsDir) {
 } else {
    winston.log('info', 'Not using translations');
 }
-
 
 
 /**

--- a/lib/Translations.js
+++ b/lib/Translations.js
@@ -35,7 +35,7 @@ function generateNameSpaces(dir) {
   };
 
 
-if (config.translationsDir) {
+if (fs.existsSync(config.translationsDir)) {
   i18next
     .use(Backend)
     .init(i18nextOptions,
@@ -49,7 +49,6 @@ if (config.translationsDir) {
 } else {
    winston.log('info', 'Not using translations');
 }
-
 
 /**
 * Run a string through i18next.t function

--- a/lib/Translations.js
+++ b/lib/Translations.js
@@ -11,8 +11,8 @@ const config = require('../config/Config.js');
 * directory e.g ['en', 'in']
 * @return {array} an array of strings that should be iso6391 language codes
 */
-function generateNameSpaces() {
-  const files = fs.readdirSync(config.translationsDir)
+function generateNameSpaces(dir) {
+  const files = fs.readdirSync(dir)
         .filter((path) => path.match(/\w*.json$/g));
   const f = files.map((file) => file.split('.')[0]);
   return f.map((path) => path
@@ -21,17 +21,9 @@ function generateNameSpaces() {
                .join('/'));
 }
 
-/**
-* Run a string through i18next.t function
-* @param {string} key - Translations are objects and we specify the key needed
-* to access the value
-* @param {object} interpolationObject - Object holding interpolations
-* @return {string} a translated language string
-*/
-function translate(key, interpolationObject) {
-  const i18nextOptions = {
-    debug: config.debugTranslations,
-    ns: generateNameSpaces(),
+ const i18nextOptions = {
+   debug: config.debugTranslations,
+   ns: generateNameSpaces(config.translationsDir),
     defaultNS: config.defaultLanguage,
     fallbackLng: config.defaultLanguage,
     backend: {loadPath: config.translationsDir + '/{{{ns}}}.json'},
@@ -41,6 +33,8 @@ function translate(key, interpolationObject) {
     },
   };
 
+
+if (config.translationsDir) {
   i18next
     .use(Backend)
     .init(i18nextOptions,
@@ -50,8 +44,21 @@ function translate(key, interpolationObject) {
             } else {
               winston.log('info', 'Translations loaded successfully');
             }
-  });
+          });
+} else {
+   winston.log('info', 'Not using translations');
+}
 
+
+
+/**
+* Run a string through i18next.t function
+* @param {string} key - Translations are objects and we specify the key needed
+* to access the value
+* @param {object} interpolationObject - Object holding interpolations
+* @return {string} a translated language string
+*/
+function translate(key, interpolationObject) {
   return i18next.t(key, interpolationObject);
 }
 

--- a/lib/services/RapidPro.js
+++ b/lib/services/RapidPro.js
@@ -72,7 +72,7 @@ function deleteContact(messengerId,
 * when a urn is used the response object has the following structure
 * {... results: [contactObject]}
 */
-function getContact({uuid, urn}, baseURL = rapidProBaseURL) {
+function getContact({uuid, urn}, baseURL = contactsEndPoint) {
   const queryParam = uuid ? `uuid=${uuid}` : `urn=${urn}`;
     return getRapidPro( `${baseURL}?${queryParam}`);
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/goodbotai/borq",
   "dependencies": {
-    "botkit": "0.5.8",
+    "botkit": "0.6.6",
     "express-winston": "^2.4.0",
     "i18next": "^9.1.0",
     "i18next-node-fs-backend": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,6 +229,15 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 ajv@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
@@ -280,6 +289,10 @@ ampersand-version@^1.0.0, ampersand-version@^1.0.2:
   dependencies:
     find-root "^0.1.1"
     through2 "^0.6.3"
+
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-escapes@^2.0.0:
   version "2.0.0"
@@ -397,7 +410,11 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws4@^1.2.1:
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
+aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -409,7 +426,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-polyfill@^6.23.0:
+babel-polyfill@^6.23.0, babel-polyfill@^6.3.14:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -481,9 +498,21 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-botbuilder@^3.7.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/botbuilder/-/botbuilder-3.9.0.tgz#363ca6b965d603a87316fb15e52b1fc8a39f40cb"
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  dependencies:
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
+
+botbuilder@^3.8.4:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/botbuilder/-/botbuilder-3.11.0.tgz#6869cbd13394576badb5f7eb2ad58a3651c0ac1c"
   dependencies:
     async "^1.5.2"
     base64url "^2.0.0"
@@ -495,26 +524,26 @@ botbuilder@^3.7.0:
     sprintf-js "^1.0.3"
     url-join "^1.1.0"
 
-botkit-studio-sdk@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/botkit-studio-sdk/-/botkit-studio-sdk-1.0.2.tgz#f20cc683a0b73aff922e92586910236d371c0f80"
+botkit-studio-sdk@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/botkit-studio-sdk/-/botkit-studio-sdk-1.0.3.tgz#324e60b9d7db34b1265c5470e8cbeb4a2140e4b5"
   dependencies:
     promise "^7.1.1"
     request "^2.67.0"
 
-botkit@0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/botkit/-/botkit-0.5.8.tgz#d1fbde81c8c91f638a9af7da0badfdd43e8f5e73"
+botkit@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/botkit/-/botkit-0.6.6.tgz#aec0f001b1d67649e708cdc9fd4e6309c9341477"
   dependencies:
     async "^2.1.5"
     back "^1.0.1"
     body-parser "^1.17.1"
-    botbuilder "^3.7.0"
-    botkit-studio-sdk "^1.0.2"
+    botbuilder "^3.8.4"
+    botkit-studio-sdk "^1.0.3"
     ciscospark "1.8.0"
     clone "2.1.1"
     command-line-args "^4.0.2"
-    crypto "0.0.3"
+    debug "^2.6.6"
     express "^4.15.2"
     https-proxy-agent "^2.0.0"
     jfs "^0.2.6"
@@ -523,7 +552,9 @@ botkit@0.5.8:
     mustache "^2.3.0"
     promise "^8.0.0"
     request "^2.81.0"
+    requestretry "^1.12.0"
     twilio "^2.11.1"
+    vorpal "^1.12.0"
     ware "^1.3.0"
     ws "^2.2.2"
 
@@ -585,7 +616,7 @@ chai@^4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -653,11 +684,21 @@ ciscospark@1.8.0:
     envify "^3.4.1"
     lodash "^4.17.4"
 
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-width@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-1.1.1.tgz#a4d293ef67ebb7b88d4a4d42c0ccf00c4d1e366d"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -795,9 +836,11 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-crypto@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-0.0.3.tgz#470a81b86be4c5ee17acc8207a1f5315ae20dbb0"
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  dependencies:
+    boom "5.x.x"
 
 cycle@1.0.x:
   version "1.0.3"
@@ -824,6 +867,12 @@ debug@2.6.8, debug@^2.4.1:
 debug@3.1.0, debug@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.6.6:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -1084,6 +1133,10 @@ etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
 
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+
 express-winston@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/express-winston/-/express-winston-2.4.0.tgz#27ab6cd93053e2dfdc35bceea14a077dc7d52e49"
@@ -1124,7 +1177,7 @@ express@^4.15.2:
     utils-merge "1.0.0"
     vary "~1.1.1"
 
-extend@~3.0.0:
+extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -1148,9 +1201,20 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -1222,6 +1286,14 @@ form-data@~1.0.0-rc4:
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
+form-data@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -1318,6 +1390,10 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -1333,6 +1409,13 @@ har-validator@~4.2.1:
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -1357,6 +1440,15 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+hawk@~6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
@@ -1364,6 +1456,10 @@ he@1.1.1:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 htmlparser2@^3.9.0:
   version "3.9.2"
@@ -1390,6 +1486,14 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -1427,6 +1531,10 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1444,6 +1552,23 @@ ink-docstrap@^1.3.0:
   dependencies:
     moment "^2.14.1"
     sanitize-html "^1.13.0"
+
+inquirer@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.11.0.tgz#7448bfa924092af311d47173bbab990cae2bb027"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^1.0.1"
+    figures "^1.3.5"
+    lodash "^3.3.1"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
 
 inquirer@^3.0.6:
   version "3.2.1"
@@ -1714,13 +1839,24 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^3.3.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@~4.11.1:
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.11.2.tgz#d6b4338b110a58e21dae5cebcfdbbfd2bc4cdb3b"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -1757,11 +1893,21 @@ mime-db@~1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
 mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
   dependencies:
     mime-db "~1.29.0"
+
+mime-types@~2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -1790,6 +1936,10 @@ minami@^1.2.3:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
@@ -1828,6 +1978,10 @@ mustache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -1847,6 +2001,10 @@ node-fetch@^1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-localstorage@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-0.6.0.tgz#45a0601c6932dfde6644a23361f1be173c75d3af"
+
 node-uuid@~1.4.3, node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
@@ -1855,7 +2013,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-oauth-sign@~0.8.1:
+oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -1863,7 +2021,7 @@ object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1878,6 +2036,10 @@ once@^1.3.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -1944,6 +2106,10 @@ pathval@^1.0.0:
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -2038,6 +2204,10 @@ qs@~6.2.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
 
+qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -2092,6 +2262,14 @@ readable-stream@~2.0.5:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
+
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
 
 recast@^0.11.17:
   version "0.11.23"
@@ -2167,6 +2345,42 @@ request@2.81.0, request@^2.67.0, request@^2.69.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+request@^2.74.0:
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
+requestretry@^1.12.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/requestretry/-/requestretry-1.12.2.tgz#13ce38a4ce4e809f3c9ec6d4ca3b7b9ba4acf26c"
+  dependencies:
+    extend "^3.0.0"
+    lodash "^4.15.0"
+    request "^2.74.0"
+    when "^3.7.7"
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -2177,6 +2391,13 @@ require-uncached@^1.0.3:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -2195,6 +2416,12 @@ rsa-pem-from-mod-exp@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz#362a42c6d304056d493b3f12bceabb2c6576a6d4"
 
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  dependencies:
+    once "^1.3.0"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -2211,11 +2438,15 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
 safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -2298,6 +2529,12 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+sntp@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
+  dependencies:
+    hoek "4.x.x"
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -2371,7 +2608,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4:
+stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -2467,6 +2704,12 @@ topo@1.x.x:
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
 
@@ -2581,6 +2824,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vorpal@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/vorpal/-/vorpal-1.12.0.tgz#4be7b2a4e48f8fcfc9cf3648c419d311c522159d"
+  dependencies:
+    babel-polyfill "^6.3.14"
+    chalk "^1.1.0"
+    in-publish "^2.0.0"
+    inquirer "0.11.0"
+    lodash "^4.5.1"
+    log-update "^1.0.2"
+    minimist "^1.2.0"
+    node-localstorage "^0.6.0"
+    strip-ansi "^3.0.0"
+    wrap-ansi "^2.0.0"
+
 ware@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ware/-/ware-1.3.0.tgz#d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4"
@@ -2592,6 +2850,10 @@ webrtc-adapter@3.2.0:
   resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-3.2.0.tgz#53f5f0336f67f7f3b091ff8b6a03f399923c09ca"
   dependencies:
     sdp "^1.3.0"
+
+when@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Remove express winston middleware
Stop requiring delivery

Call `controller.startTicking()` in start.

Changes in the FB messenger API have rendered 0.6.6 unstable and we will have to update to update borq to a newer version of botkit as soon as the issues are addressed.

Fixes #40 