### PR TITLE
Specify language code for indonesia as id

### DIFF
--- a/lib/utils/Locales.js
+++ b/lib/utils/Locales.js
@@ -21,9 +21,9 @@ const languages = [
 
   },
   {
-    locale: 'in_ID',
+    locale: 'id_ID',
     name: 'Indonesian',
-    iso6391: 'in',
+    iso6391: 'id',
     iso6392: 'ind',
   },
 ];


### PR DESCRIPTION
Locale should be id_ID not in_ID and the ISO6391 language code is id.