### PR TITLE
Allow setting facebookBot.api_host

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -21,6 +21,8 @@ module.exports = {
   facebookAppSecret: env.FACEBOOK_APP_SECRET,
   facebookApiVersion: env.FACEBOOK_API_VERSION || 'v2.10',
   facebookVerifyToken: env.FACEBOOK_VERIFY_TOKEN || 'borq',
+  facebookApiHost: env.FACEBOOK_API_HOST ||
+    /test\w*/i.test(env.NODE_ENV) ? 'http://256.256.256.256' : undefined,
 
   // external data stores
   onaOrg: env.ONA_USERNAME,

--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -3,26 +3,27 @@ them to create a functioning bot.
 
 |        Environment variable      |                                     Descpription                                           |         Default         |
 |:--------------------------------:|:------------------------------------------------------------------------------------------:|:-----------------------:|
-|NODE_ENV                          |test, dev and production                                                                    |'dev'                    |
-|DEAFULT_LANGUAGE (ISO 639-1 Code) |The language you want the bot to communicate in.                                            |'en'                     |
-|HOST_PORT (docker)                |Container port in the host                                                                  |undefined                |
-|APP_PORT (docker)                 |App port in the container                                                                   |3000                     |
-|PORT                              |Port that your bot is listening on. If in docker APP_PORT = PORT                            |3000                     |
-|ONA_USERNAME                      |Ona user or organization username                                                           |undefined                |
-|ONA_FORM_IDS                      |JSON Object of Ona form ID strings. We use it to identify the form to make submissins to.   |{}                       |
-|ONA_API_TOKEN                     |API token provided by Ona. Required if sending data to Ona.                                 |undefined                |
-|RAPIDPRO_API_TOKEN                |API token provided by Rapidpro. Required if creating or updating RapidPro contacts.         |undefined                |
-|RAPIDPRO_GROUPS                   |JSON Object of keys to Rapidpro group UUIDs that your users should be added to              |{}                       |
-|DELETED_USER_RAPIDPRO_GROUPS      |JSON Object of keys to Rapidpro group UUIDs that your users should be moved to              |{}                       |
-|SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                |
-|ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log           |
-|DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                    |
-|TRANSLATIONS_DIR                  |Path to the dir holding the translations files.                                             |'./translations'         |
-|FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                   |
-|FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                |
-|CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)     |
-|FACEBOOK_PAGE_ACCESS_TOKEN        |Facebook provided token needed to post as a page. Required for Messenger.                   |undefined                |
-|FACEBOOK_API_VERSION              |The version of the facebook API to use when making Facebook API calls.                      |'v2.10'                  |
+|NODE_ENV                          |test, dev and production                                                                    |'dev'                               |
+|DEAFULT_LANGUAGE (ISO 639-1 Code) |The language you want the bot to communicate in.                                            |'en'                                |
+|HOST_PORT (docker)                |Container port in the host                                                                  |undefined                           |
+|APP_PORT (docker)                 |App port in the container                                                                   |3000                                |
+|PORT                              |Port that your bot is listening on. If in docker APP_PORT = PORT                            |3000                                |
+|ONA_USERNAME                      |Ona user or organization username                                                           |undefined                           |
+|ONA_FORM_IDS                      |JSON Object of Ona form ID strings. We use it to identify the form to make submissins to.   |{}                                  |
+|ONA_API_TOKEN                     |API token provided by Ona. Required if sending data to Ona.                                 |undefined                           |
+|RAPIDPRO_API_TOKEN                |API token provided by Rapidpro. Required if creating or updating RapidPro contacts.         |undefined                           |
+|RAPIDPRO_GROUPS                   |JSON Object of keys to Rapidpro group UUIDs that your users should be added to              |{}                                  |
+|DELETED_USER_RAPIDPRO_GROUPS      |JSON Object of keys to Rapidpro group UUIDs that your users should be moved to              |{}                                  |
+|SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                           |
+|ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log                      |
+|DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                               |
+|TRANSLATIONS_DIR                  |Path to the dir holding the translations files.                                             |'./translations'                    |
+|FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                              |
+|FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                           |
+|FACEBOOK_API_HOST                 |Set the api_host. In testing `http://256.256.256.256` in any other env `undefined`          | undefined or http://256.256.256.256|
+|CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)                |
+|FACEBOOK_PAGE_ACCESS_TOKEN        |Facebook provided token needed to post as a page. Required for Messenger.                   |undefined                           |
+|FACEBOOK_API_VERSION              |The version of the facebook API to use when making Facebook API calls.                      |'v2.10'                             |
 
 
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -11,6 +11,7 @@ const controller = Botkit.facebookbot({
   access_token: Config.facebookPageAccessToken,
   verify_token: Config.facebookVerifyToken,
   app_secret: Config.facebookAppSecret,
+  api_host: Config.facebookApiHost,
   validate_requests: true,
   stats_optout: true,
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "borq",
-  "version": "0.0.1-alpha.25",
+  "version": "0.0.1-alpha.26",
   "description": "Bot orchestration framework",
   "main": "lib/Borq.js",
   "scripts": {


### PR DESCRIPTION
We do not want to make requests to Facebook during load tests or testing at all.


Fixes #50 