### PR TITLE
Send logs to graylog

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -39,6 +39,10 @@ module.exports = {
 
   // logging and error reporting
   sentryDSN: env.SENTRY_DSN,
+  hostname: env.HOSTNAME || 'borq',
+  facility: env.FACILITY || 'localhost',
+  graylogHost: env.GRAYLOG_HOST,
+  graylogPort: env.GRAYLOG_PORT,
   karmaAccessLogFile: env.KARMA_ACCESS_LOG_FILE || 'bot.access.log',
   debugTranslations: env.DEBUG_TRANSLATIONS === 'true' || false,
 };

--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -1,30 +1,34 @@
 None of these vars is required by themselves but you need to set a few of
 them to create a functioning bot.
 
-|        Environment variable      |                                     Descpription                                           |                Default             |
-|:--------------------------------:|:------------------------------------------------------------------------------------------:|:----------------------------------:|
-|NODE_ENV                          |test, dev and production                                                                    |'dev'                               |
-|DEBUG                             |To run in debug mode or not                                                                 |false                               |
-|DEAFULT_LANGUAGE (ISO 639-1 Code) |The language you want the bot to communicate in.                                            |'en'                                |
-|HOST_PORT (docker)                |Container port in the host                                                                  |undefined                           |
-|APP_PORT (docker)                 |App port in the container                                                                   |3000                                |
-|PORT                              |Port that your bot is listening on. If in docker APP_PORT = PORT                            |3000                                |
-|ONA_USERNAME                      |Ona user or organization username                                                           |undefined                           |
-|ONA_FORM_IDS                      |JSON Object of Ona form ID strings. We use it to identify the form to make submissins to.   |{}                                  |
-|ONA_API_TOKEN                     |API token provided by Ona. Required if sending data to Ona.                                 |undefined                           |
-|RAPIDPRO_API_TOKEN                |API token provided by Rapidpro. Required if creating or updating RapidPro contacts.         |undefined                           |
-|RAPIDPRO_GROUPS                   |JSON Object of keys to Rapidpro group UUIDs that your users should be added to              |{}                                  |
-|DELETED_USER_RAPIDPRO_GROUPS      |JSON Object of keys to Rapidpro group UUIDs that your users should be moved to              |{}                                  |
-|SENTRY_DSN                        |DSN provided by Sentry                                                                      |undefined                           |
-|ACCESS_LOG_FILE                   |File to store access logs                                                                   |bot.access.log                      |
-|DEBUG_TRANSLATIONS                |Whether to turn off or on translations debugging                                            |false                               |
-|TRANSLATIONS_DIR                  |Path to the dir holding the translations files.                                             |'./translations'                    |
-|FACEBOOK_VERIFY_TOKEN             |Token used to verify your app to the webhooks endpoint listens on /facebook/recieve         |'borq'                              |
-|FACEBOOK_APP_SECRET               |Facebook provided app secret. Required for Messenger.                                       |undefined                           |
-|FACEBOOK_API_HOST                 |Set the api_host. In testing `http://256.256.256.256` in any other env `undefined`          | undefined or http://256.256.256.256|
-|CONVERSATION_TIMEOUT              |Time to wait for a user to respond (in milliseconds).                                       |60000 * 20 (20 mins)                |
-|FACEBOOK_PAGE_ACCESS_TOKEN        |Facebook provided token needed to post as a page. Required for Messenger.                   |undefined                           |
-|FACEBOOK_API_VERSION              |The version of the facebook API to use when making Facebook API calls.                      |'v2.10'                             |
+| Environment variable               | Descpription                                                                                 | Default                              |
+| :--------------------------------: | :------------------------------------------------------------------------------------------: | :----------------------------------: |
+| NODE_ENV                           | test, dev and production                                                                     | 'dev'                                |
+| DEBUG                              | To run in debug mode or not                                                                  | false                                |
+| DEAFULT_LANGUAGE (ISO 639-1 Code)  | The language you want the bot to communicate in.                                             | 'en'                                 |
+| HOST_PORT (docker)                 | Container port in the host                                                                   | undefined                            |
+| APP_PORT (docker)                  | App port in the container                                                                    | 3000                                 |
+| PORT                               | Port that your bot is listening on. If in docker APP_PORT = PORT                             | 3000                                 |
+| ONA_USERNAME                       | Ona user or organization username                                                            | undefined                            |
+| ONA_FORM_IDS                       | JSON Object of Ona form ID strings. We use it to identify the form to make submissins to.    | {}                                   |
+| ONA_API_TOKEN                      | API token provided by Ona. Required if sending data to Ona.                                  | undefined                            |
+| RAPIDPRO_API_TOKEN                 | API token provided by Rapidpro. Required if creating or updating RapidPro contacts.          | undefined                            |
+| RAPIDPRO_GROUPS                    | JSON Object of keys to Rapidpro group UUIDs that your users should be added to               | {}                                   |
+| DELETED_USER_RAPIDPRO_GROUPS       | JSON Object of keys to Rapidpro group UUIDs that your users should be moved to               | {}                                   |
+| SENTRY_DSN                         | DSN provided by Sentry                                                                       | undefined                            |
+| ACCESS_LOG_FILE                    | File to store access logs                                                                    | bot.access.log                       |
+| DEBUG_TRANSLATIONS                 | Whether to turn off or on translations debugging                                             | false                                |
+| TRANSLATIONS_DIR                   | Path to the dir holding the translations files.                                              | './translations'                     |
+| FACEBOOK_VERIFY_TOKEN              | Token used to verify your app to the webhooks endpoint listens on /facebook/recieve          | 'borq'                               |
+| FACEBOOK_APP_SECRET                | Facebook provided app secret. Required for Messenger.                                        | undefined                            |
+| FACEBOOK_API_HOST                  | Set the api_host. In testing `http://256.256.256.256` in any other env `undefined`           | undefined or http://256.256.256.256  |
+| CONVERSATION_TIMEOUT               | Time to wait for a user to respond (in milliseconds).                                        | 60000 * 20 (20 mins)                 |
+| FACEBOOK_PAGE_ACCESS_TOKEN         | Facebook provided token needed to post as a page. Required for Messenger.                    | undefined                            |
+| FACEBOOK_API_VERSION               | The version of the facebook API to use when making Facebook API calls.                       | 'v2.10'                              |
+| GRAYLOG_HOST                       | Graylog server address                                                                       | 'localhost'                          |
+| GRAYLOG_PORT                       | Graylog server port                                                                          | 12201                                |
+| FACILITY                           | Application or container specific identifying string                                         | 'localhost'                          |
+| HOSTNAME                           | The name of the host                                                                         | 'borq'                               |
 
 
 

--- a/lib/HTTP.js
+++ b/lib/HTTP.js
@@ -42,6 +42,7 @@ function processResponse(response, payload, url) {
    */
   function log(r) {
     Logger.log(logLevel, {
+      message: 'HTTP response',
       Status: status,
       URL: url,
       Payload: payload,

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -44,7 +44,7 @@ function log(logLevel, message, metadata) {
   const msg = message.message || '';
 
   if (typeof message === 'object' && !metadata) {
-    logger.log(level, msg);
+    logger.log(level, msg, message);
   } else if (typeof message === 'object' && metadata) {
     logger.log(level, msg, metadata);
   } else if (typeof message === 'string' && !metadata) {

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,3 +1,4 @@
+/** @module logger */
 const raven = require('raven');
 const winston = require('winston');
 
@@ -13,10 +14,21 @@ if (/dev\w*/i.test(Config.environment)) {
   });
 }
 
-if (/prod\w*/i.test(Config.environment)) {
+// if not dev or test so e.g prod, staging, canary etc
+if  (!/dev\w*|test\w*/i.test(Config.environment)) {
   logger.add(winston.transports.Console, {
     timestamp: true,
     json: true,
+  });
+  logger.add(require('winston-graylog2'), {
+    name: 'Graylog',
+    prelog: JSON.stringify,
+    staticMeta: {environment: Config.environment},
+    graylog: {
+      servers: [{host: Config.graylogHost, port: Config.graylogPort}],
+      hostname: Config.hostname,
+      facility: Config.facility,
+    },
   });
 }
 
@@ -24,13 +36,21 @@ if (/prod\w*/i.test(Config.environment)) {
  * A wrapper around logger.log because we can't export log on it's own
  * meant to be used as borq.log
  * @param {string} logLevel - The logLevel like error, warn etc.
- * @param {string} message - the message to log
+ * @param {string} message - message of log, this could also just be a JSON object holding the message & metadata
+ * @param {object} metadata - metadata for the log if the previous argument (message) is an object there's no need for this argment.
  */
-function log(logLevel, message) {
-  if (!message) {
-    logger.log(logLevel);
+function log(logLevel, message, metadata) {
+  const level = message ? logLevel : 'info';
+  const msg = message.message || '';
+
+  if (typeof message === 'object' && !metadata) {
+    logger.log(level, msg);
+  } else if (typeof message === 'object' && metadata) {
+    logger.log(level, msg, metadata);
+  } else if (typeof message === 'string' && !metadata) {
+    logger.log(level, message);
   } else {
-    logger.log(logLevel, message);
+    logger.log(level, message, metadata);
   }
 }
 

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -15,7 +15,7 @@ if (/dev\w*/i.test(Config.environment)) {
 }
 
 // if not dev or test so e.g prod, staging, canary etc
-if  (!/dev\w*|test\w*/i.test(Config.environment)) {
+if (!/dev\w*|test\w*/i.test(Config.environment)) {
   logger.add(winston.transports.Console, {
     timestamp: true,
     json: true,

--- a/lib/Translations.js
+++ b/lib/Translations.js
@@ -43,9 +43,18 @@ function translateiUsing18next() {
 
     i18next.use(Backend).init(i18nextOptions, (err, t) => {
       if (err) {
-        Logger.log('error', `Error loading translations: ${t}`, err);
+        Logger.log('error', {
+          message: `Error loading translations: ${t}`,
+          error: err,
+          dir: config.defaultLanguage,
+          defaultLanguage: config.defaultLanguage,
+        });
       } else {
-        Logger.log('info', 'Translations loaded successfully');
+        Logger.log('info', {
+          message: 'Translations loaded successfully',
+          dir: config.defaultLanguage,
+          defaultLanguage: config.defaultLanguage,
+        });
       }
     });
   } else {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "rapidpro-js": "^0.0.1-alpha.2",
     "raven": "^2.1.1",
     "uuid": "^3.1.0",
-    "winston": "^2.3.1"
+    "winston": "^2.3.1",
+    "winston-graylog2": "^0.7.1"
   },
   "devDependencies": {
     "eslint": "^4.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,6 +1969,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graylog2@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/graylog2/-/graylog2-0.2.1.tgz#fcb0775766fb6d7d6f5fef3ff873326b8b1d35a9"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -4693,9 +4697,28 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
+winston-graylog2@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/winston-graylog2/-/winston-graylog2-0.7.1.tgz#c414a1de6d4035a908718ee16162e66b4355b40b"
+  dependencies:
+    graylog2 "^0.2.1"
+    lodash "^4.17.5"
+    winston "^2.4.0"
+
 winston@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.0.tgz#808050b93d52661ed9fb6c26b3f0c826708b0aee"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
+
+winston@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.1.tgz#a3a9265105564263c6785b4583b8c8aca26fded6"
   dependencies:
     async "~1.0.0"
     colors "1.0.x"


### PR DESCRIPTION
Added a graylog 2 winston transport and configured the logging module to send logs to graylog for non test and non dev environments.

Graylog configs must be set as env vars: 
  * GRAYLOG_HOST 
  * GRAYLOG_PORT  
  * FACILITY      
  * HOSTNAME

Fixes #69 